### PR TITLE
Remove dependency upon numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install via `pip install watchlogs`.  If you prefer to hack around with the sour
 ### Dependencies
 
 * `Python >= 3.6`
-* `seaborn`
+* `hsluv`
 * `colored`
 * `tailf`
 * `psutil`

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=[
         "colored",
-        "seaborn",
+        "hsluv",
         "tailf",
         "psutil",
         "humanize",

--- a/watchlogs/watchlogs.py
+++ b/watchlogs/watchlogs.py
@@ -10,11 +10,9 @@ import threading
 from typing import Callable, Union, List
 from pathlib import Path
 
-import numpy as np
 import tailf
 import psutil
 import colored
-import seaborn as sns
 import humanize
 from typeguard import typechecked
 
@@ -26,6 +24,14 @@ def memory_summary():
         f"{humanize.naturalsize(vmem.used)}/{humanize.naturalsize(vmem.available)}"
     )
     print(msg)
+
+
+def get_colors(n_colors):
+    import hsluv
+    return [
+        hsluv.hpluv_to_hex((idx * 360.0 / n_colors, 90, 65))
+        for idx in range(n_colors)
+    ]
 
 
 class Watcher:
@@ -45,7 +51,7 @@ class Watcher:
         self.heartbeat = heartbeat
         self.halting_condition = halting_condition
         self.conserve_resources = conserve_resources
-        colors = sns.color_palette("husl", len(watched_logs)).as_hex()
+        colors = get_colors(len(watched_logs))
         self.last_path = None
 
         for path, color in zip(watched_logs, colors):
@@ -91,7 +97,7 @@ class Watcher:
         if self.prev_buffer_size > -1:
             lines = lines[-self.prev_buffer_size:]
         self.log_content(path, lines)
-        num_digits = int(np.ceil(math.log(total_watchers, 10)))
+        num_digits = math.ceil(math.log(total_watchers, 10))
         if not lines:
             lines = [""]
         latest = {"line": lines[-1], "tic": time.time()}


### PR DESCRIPTION
Currently numpy is being pulled in directly and by seaborn, but it doesn't seem to be being used a lot. This patch removes the dependency, and replaces it with hsluv.